### PR TITLE
Use a token generated by GitHub Apps to launch recursive workflows

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Generate token # to trigger other workflows
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.TRIGGER_APP_ID }}
+          private_key: ${{ secrets.TRIGGER_APP_PRIVATE_KEY }}
       - uses: Songmu/tagpr@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
When tagpr use a default GITHUB_TOKEN to create a PR, a next workflow triggered by the PR doesn't run. To trigger the workflow, use a token generated by GitHub Apps instead.