### PR TITLE
Group multiple dependencies in a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # Group development dependencies in a single PR
+      dev:
+        dependency-type: development
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # Group all updates in a single PR
+      all:
+        patterns: ["*"]


### PR DESCRIPTION
This PR reduces a numbers of dependabot PRs by grouping multiple dependencies.

ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

