### PR TITLE
Don't fetch tags when event type is release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 100
-          fetch-tags: true
+          # When event is 'release', fetching tag is not required
+          fetch-tags: ${{ github.event_name != 'release' }}
       - name: Use Python 3.9
         uses: actions/setup-python@v5
         id: cp39


### PR DESCRIPTION
When event type is "release", GitHub Actions already fetch a corresponding tag. So, checkout action should not have "fetch-tags: true".

Behavior of `fetch-tags` parameter is very confusing. <https://github.com/actions/checkout/issues/1467>
